### PR TITLE
change Elasticsearch ID to UUID and remove tracking elasticsearch ID altogether

### DIFF
--- a/app/src/main/java/Controllers/ElasticsearchPatientController.java
+++ b/app/src/main/java/Controllers/ElasticsearchPatientController.java
@@ -203,6 +203,7 @@ public class ElasticsearchPatientController {
             Patient patient = Patients[0];
             Index index=new Index.Builder(patient)
                     .index(getIndex())
+                    .id(patient.getUUID())
                     .type("Patient")
                     .build();
 
@@ -211,8 +212,6 @@ public class ElasticsearchPatientController {
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        //add id to current object
-                        patient.setElasticSearchID(result.getId());
                         Log.d("AddPatient", "Success, added " + patient.getUserID());
                         return TRUE;
                     } else {
@@ -301,7 +300,7 @@ public class ElasticsearchPatientController {
                             new Index.Builder(patient)
                                     .index(getIndex())
                                     .type("Patient")
-                                    .id(patient.getElasticSearchID())
+                                    .id(patient.getUUID())
                                     .build()
                     );
 

--- a/app/src/main/java/Controllers/ElasticsearchPatientRecordController.java
+++ b/app/src/main/java/Controllers/ElasticsearchPatientRecordController.java
@@ -272,6 +272,7 @@ public class ElasticsearchPatientRecordController {
             Index index=new Index.Builder(patientRecord)
                     .index(getIndex())
                     .type("PatientRecord")
+                    .id(patientRecord.getUUID())
                     .build();
 
             int tryCounter = NumberOfElasticsearchRetries;
@@ -279,8 +280,6 @@ public class ElasticsearchPatientRecordController {
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        //add id to current object
-                        patientRecord.setElasticSearchID(result.getId());
                         Log.d("AddPatientRecord", "Success, added " + patientRecord.toString());
                         return TRUE;
                     } else {
@@ -317,7 +316,7 @@ public class ElasticsearchPatientRecordController {
                             new Index.Builder(patientRecord)
                                     .index(getIndex())
                                     .type("PatientRecord")
-                                    .id(patientRecord.getElasticSearchID())
+                                    .id(patientRecord.getUUID())
                                     .build()
                     );
 

--- a/app/src/main/java/Controllers/ElasticsearchProblemController.java
+++ b/app/src/main/java/Controllers/ElasticsearchProblemController.java
@@ -338,6 +338,7 @@ public class ElasticsearchProblemController {
             Problem problem = Problems[0];
             Index index=new Index.Builder(problem)
                     .index(getIndex())
+                    .id(problem.getUUID())
                     .type("Problem")
                     .build();
 
@@ -346,8 +347,6 @@ public class ElasticsearchProblemController {
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        //add id to current object
-                        problem.setElasticSearchID(result.getId());
                         Log.d("AddProblem", "Success, added " + problem.toString());
                         return TRUE;
                     } else {
@@ -384,7 +383,7 @@ public class ElasticsearchProblemController {
                             new Index.Builder(problem)
                                     .index(getIndex())
                                     .type("Problem")
-                                    .id(problem.getElasticSearchID())
+                                    .id(problem.getUUID())
                                     .build()
                     );
 

--- a/app/src/main/java/Controllers/ElasticsearchProviderController.java
+++ b/app/src/main/java/Controllers/ElasticsearchProviderController.java
@@ -201,6 +201,7 @@ public class ElasticsearchProviderController {
             Index index=new Index.Builder(provider)
                     .index(getIndex())
                     .type("Provider")
+                    .id(provider.getUUID())
                     .build();
 
             int tryCounter = NumberOfElasticsearchRetries;
@@ -208,8 +209,6 @@ public class ElasticsearchProviderController {
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        //add id to current object
-                        provider.setElasticSearchID(result.getId());
                         Log.d("AddProvider", "Success, added " + provider.getUserID());
                         return TRUE;
                     } else {
@@ -246,7 +245,7 @@ public class ElasticsearchProviderController {
                             new Index.Builder(provider)
                                     .index(getIndex())
                                     .type("Provider")
-                                    .id(provider.getElasticSearchID())
+                                    .id(provider.getUUID())
                                     .build()
                     );
 

--- a/app/src/main/java/Controllers/ElasticsearchRecordController.java
+++ b/app/src/main/java/Controllers/ElasticsearchRecordController.java
@@ -273,6 +273,7 @@ public class ElasticsearchRecordController {
             Index index=new Index.Builder(record)
                     .index(getIndex())
                     .type("Record")
+                    .id(record.getUUID())
                     .build();
 
             int tryCounter = NumberOfElasticsearchRetries;
@@ -280,8 +281,6 @@ public class ElasticsearchRecordController {
                 try {
                     DocumentResult result = client.execute(index);
                     if (result.isSucceeded()) {
-                        //add id to current object
-                        record.setElasticSearchID(result.getId());
                         Log.d("AddRecord", "Success, added " + record.toString());
                         return TRUE;
                     } else {
@@ -318,7 +317,7 @@ public class ElasticsearchRecordController {
                             new Index.Builder(record)
                                     .index(getIndex())
                                     .type("Record")
-                                    .id(record.getElasticSearchID())
+                                    .id(record.getUUID())
                                     .build()
                     );
 

--- a/app/src/main/java/com/cmput301f18t20/medicalphotorecord/Problem.java
+++ b/app/src/main/java/com/cmput301f18t20/medicalphotorecord/Problem.java
@@ -25,14 +25,12 @@ import io.searchbox.annotations.JestId;
 
 public class Problem implements Serializable {
     @JestId
-    protected String ElasticSearchID;
+    protected final String UUID = java.util.UUID.randomUUID().toString();
     protected ArrayList<Record> records = new ArrayList<>();
     protected String description, title, createdByUserID;
     protected Date
             dateCreated = new Date(System.currentTimeMillis()),
             dateLastModified = new Date(System.currentTimeMillis());
-
-    protected final String UUID = java.util.UUID.randomUUID().toString();
 
     public Problem(String createdByUserID, String title)
             throws UserIDMustBeAtLeastEightCharactersException, TitleTooLongException {
@@ -42,14 +40,6 @@ public class Problem implements Serializable {
 
     public String getUUID() {
         return UUID;
-    }
-
-    public String getElasticSearchID() {
-        return ElasticSearchID;
-    }
-
-    public void setElasticSearchID(String elasticSearchID) {
-        ElasticSearchID = elasticSearchID;
     }
 
     public Record getRecord(int recordIndex) {

--- a/app/src/main/java/com/cmput301f18t20/medicalphotorecord/Record.java
+++ b/app/src/main/java/com/cmput301f18t20/medicalphotorecord/Record.java
@@ -24,13 +24,11 @@ import io.searchbox.annotations.JestId;
 public class Record implements Serializable {
 
     @JestId
-    protected String ElasticSearchID;
+    protected final String UUID = java.util.UUID.randomUUID().toString();
     protected String associatedProblemUUID, createdByUserID, comment, title, description;
     protected Date
             dateCreated = new Date(System.currentTimeMillis()),
             dateLastModified = new Date(System.currentTimeMillis());
-
-    protected final String UUID = java.util.UUID.randomUUID().toString();
 
     public Record(String creatorUserID, String title)
             throws UserIDMustBeAtLeastEightCharactersException, TitleTooLongException {
@@ -50,14 +48,6 @@ public class Record implements Serializable {
     //TODO NEEDS TESTING
     public void setAssociatedProblemUUID(String associatedProblemUUID) {
         this.associatedProblemUUID = associatedProblemUUID;
-    }
-    //TODO NEEDS TESTING
-    public String getElasticSearchID() {
-        return ElasticSearchID;
-    }
-    //TODO NEEDS TESTING
-    public void setElasticSearchID(String elasticSearchID) {
-        ElasticSearchID = elasticSearchID;
     }
 
     public String getDescription() {

--- a/app/src/main/java/com/cmput301f18t20/medicalphotorecord/User.java
+++ b/app/src/main/java/com/cmput301f18t20/medicalphotorecord/User.java
@@ -20,10 +20,9 @@ import io.searchbox.annotations.JestId;
 
 public class User {
     @JestId
-    protected String ElasticSearchID;
+    protected final String UUID = java.util.UUID.randomUUID().toString();
     protected String UserID, email, phoneNumber;
     protected Date dateLastModified = new Date(System.currentTimeMillis());
-    protected final String UUID = java.util.UUID.randomUUID().toString();
 
     public User(String Userid) throws UserIDMustBeAtLeastEightCharactersException {
         this.setUserID(Userid);
@@ -71,14 +70,6 @@ public class User {
 
     public String toString(){
         return this.UserID + " " + this.email + " " + this.phoneNumber;
-    }
-
-    public String getElasticSearchID() {
-        return ElasticSearchID;
-    }
-
-    public void setElasticSearchID(String elasticSearchID) {
-        ElasticSearchID = elasticSearchID;
     }
 
     public Date getDateLastModified() {


### PR DESCRIPTION
This way, the database ID is known on object creation instead of after being added to the database.  Should free up the design a little.